### PR TITLE
Add image highlight pixel ratio comparison script

### DIFF
--- a/compare_highlight_ratio.py
+++ b/compare_highlight_ratio.py
@@ -1,0 +1,30 @@
+import argparse
+from PIL import Image
+import numpy as np
+
+def highlight_ratio(path, threshold=200):
+    """Compute the proportion of pixels brighter than threshold."""
+    img = Image.open(path).convert('L')
+    arr = np.array(img)
+    ratio = np.mean(arr > threshold)
+    return ratio
+
+def main():
+    parser = argparse.ArgumentParser(description="Compare highlight pixel ratios of two images.")
+    parser.add_argument('image1', help='Path to first image')
+    parser.add_argument('image2', help='Path to second image')
+    parser.add_argument('--threshold', type=int, default=200,
+                        help='Brightness threshold (0-255) to consider a pixel highlighted')
+    args = parser.parse_args()
+
+    r1 = highlight_ratio(args.image1, args.threshold)
+    r2 = highlight_ratio(args.image2, args.threshold)
+
+    print(f"{args.image1} highlight ratio: {r1:.4f}")
+    print(f"{args.image2} highlight ratio: {r2:.4f}")
+    if r2 != 0:
+        print(f"Ratio (image1 / image2): {r1 / r2:.4f}")
+    print(f"Difference (image1 - image2): {r1 - r2:.4f}")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `compare_highlight_ratio.py` for computing the proportion of bright pixels in two images

## Testing
- `python compare_highlight_ratio.py imgs/comparison.jpg imgs/overall.jpg --threshold 200` *(fails: ModuleNotFoundError: No module named 'PIL')*
- `pip install pillow` *(fails: Could not find a version that satisfies the requirement pillow)*
- `python -m py_compile compare_highlight_ratio.py`


------
https://chatgpt.com/codex/tasks/task_e_68aaf42e38488321b4ec6fa6ad2fb358